### PR TITLE
Make DLArrays a higher order abstraction

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Pablo Zubieta"]
 version = "0.1.0"
 
 [deps]
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 
 [compat]
@@ -12,5 +13,4 @@ PyCall = "1.92"
 julia = "1.3"
 
 [extras]
-CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"

--- a/src/DLPack.jl
+++ b/src/DLPack.jl
@@ -3,15 +3,18 @@ module DLPack
 
 ##  Dependencies  ##
 
+using CUDA
 using Requires
 
 
 ##  Exports  ##
 
-export DLArray, DLMatrix, DLVector
+export DLArray, DLVector, DLMatrix, RowMajor, ColMajor
 
 
-##  Constants  ##
+##  Aliases and constants  ##
+
+ArrayOrCuArrayT{T, N} = Union{Type{Array{T, N}}, Type{CuArray{T, N}}}
 
 const PYCAPSULE_NAME = Ref(
     (0x64, 0x6c, 0x74, 0x65, 0x6e, 0x73, 0x6f, 0x72, 0x00)
@@ -19,6 +22,7 @@ const PYCAPSULE_NAME = Ref(
 const USED_PYCAPSULE_NAME = Ref(
     (0x75, 0x73, 0x65, 0x64, 0x5f, 0x64, 0x6c, 0x74, 0x65, 0x6e, 0x73, 0x6f, 0x72, 0x00)
 )
+
 
 ##  Types  ##
 
@@ -88,23 +92,61 @@ mutable struct DLManagedTensor
     end
 end
 
-struct DLArray{T, N}
-    manager::DLManagedTensor
+abstract type MemoryLayout end
 
-    function DLArray(manager::DLManagedTensor)
-        T = dtypes_to_jltypes()[manager.dl_tensor.dtype]
-        N = Int(manager.dl_tensor.ndim)
-        return new{T, N}(manager)
+struct ColMajor <: MemoryLayout end
+struct RowMajor <: MemoryLayout end
+
+struct DLManager{T, N}
+    tensor::DLManagedTensor
+
+    function DLManager(tensor::DLManagedTensor)
+        T = dtypes_to_jltypes()[tensor.dl_tensor.dtype]
+        N = Int(tensor.dl_tensor.ndim)
+        return new{T, N}(tensor)
     end
 
-    function DLArray{T, N}(manager::DLManagedTensor) where {T, N}
-        if N != (n = manager.dl_tensor.ndim)
+    function DLManager{T, N}(tensor::DLManagedTensor) where {T, N}
+        dlt = tensor.dl_tensor
+        if N != (n = dlt.ndim)
             throw(ArgumentError("Dimensionality mismatch, object ndims is $n"))
-        elseif jltypes_to_dtypes()[T] !== (D = manager.dl_tensor.dtype)
+        elseif jltypes_to_dtypes()[T] !== (D = dlt.dtype)
             throw(ArgumentError("Type mismatch, object dtype is $D"))
         end
-        return new{T, N}(manager)
+        return new{T, N}(tensor)
     end
+end
+
+struct DLArray{T, N, A <: AbstractArray{T, N}, F}
+    manager::DLManager{T, N}
+    foreign::F
+    data::A
+end
+
+function DLArray(tensor::DLManagedTensor, foreign)
+    manager = DLManager(tensor)
+    dev = device_type(tensor)
+    arr = if dev == kDLCPU
+        unsafe_wrap(Array, manager)
+    elseif dev == kDLCUDA
+        unsafe_wrap(CuArray, manager)
+    else
+        throw(ArgumentError("Unsupported device"))
+    end
+    data = is_col_major(manager) ? arr : reversedims(arr)
+    return DLArray(manager, foreign, data)
+end
+
+function DLArray{T, N}(A::TA, ::Type{M}, tensor::DLManagedTensor, foreign) where {
+    T, N, TA <: Union{Type{Array}, Type{CuArray}}, M <: MemoryLayout
+}
+    col_major = is_col_major(tensor, Val(N))
+    if (M === ColMajor && !col_major) || (M === RowMajor && col_major)
+        throw(ArgumentError("Memory layout mismatch"))
+    end
+    manager = DLManager{T, N}(tensor)
+    data = reversedims_maybe(M, unsafe_wrap(A, manager))
+    return DLArray(manager, foreign, data)
 end
 
 const DLVector{T} = DLArray{T, 1}
@@ -149,62 +191,89 @@ dtypes_to_jltypes() = Dict(
 
 device_type(ctx::DLDevice) = ctx.device_type
 device_type(tensor::DLTensor) = device_type(tensor.ctx)
-device_type(manager::DLManagedTensor) = device_type(manager.dl_tensor)
-device_type(array::DLArray) = device_type(array.manager)
+device_type(tensor::DLManagedTensor) = device_type(tensor.dl_tensor)
+device_type(manager::DLManager) = device_type(manager.tensor)
 
 Base.eltype(array::DLArray{T}) where {T} = T
 
 Base.ndims(array::DLArray{T, N}) where {T, N} = N
 
-_size(tensor::DLTensor) = tensor.shape
-_size(manager::DLManagedTensor) = _size(manager.dl_tensor)
-_size(array::DLArray) = _size(array.manager)
-
-function Base.size(array::DLArray{T, N}) where {T, N}
-    ptr = Base.unsafe_convert(Ptr{NTuple{N, Int64}}, _size(array))
-    return unsafe_load(ptr)
-end
+unsafe_size(manager::DLManager{T, N}) where {T, N} = unsafe_size(manager.tensor, Val(N))
 #
-function Base.size(array::DLArray{T, N}, d::Integer) where {T, N}
-    if 1 ≤ d
-        return d ≤ N ? size(array)[d] : Int64(1)
-    end
-    throw(ArgumentError("Dimension out of range"))
-end
-
-_strides(tensor::DLTensor) = tensor.strides
-_strides(manager::DLManagedTensor) = _strides(manager.dl_tensor)
-_strides(array::DLArray) = _strides(array.manager)
-
-function Base.strides(array::DLArray{T, N}) where {T, N}
-    ptr = Base.unsafe_convert(Ptr{NTuple{N, Int64}}, _strides(array))
+function unsafe_size(tensor::DLManagedTensor, ::Val{N}) where {N}
+    sz = tensor.dl_tensor.shape
+    ptr = Base.unsafe_convert(Ptr{NTuple{N, Int64}}, sz)
     return unsafe_load(ptr)
 end
+
+Base.size(array::DLArray) = size(array.data)
+Base.size(array::DLArray, d::Integer) = size(array.data, d)
+
+function unsafe_strides(tensor::DLManagedTensor, val::Val{N}) where {N}
+    st = tensor.dl_tensor.strides
+    if st == C_NULL
+        trailing_size = Base.rest(unsafe_size(tensor, val), 2)
+        tup = ((reverse ∘ cumprod ∘ reverse)(trailing_size)..., 1)
+        return NTuple{N, Int64}(tup)
+    end
+    ptr = Base.unsafe_convert(Ptr{NTuple{N, Int64}}, st)
+    return unsafe_load(ptr)
+end
+
+Base.strides(a::DLArray) = strides(a.data)
 
 byte_offset(tensor::DLTensor) = Int(tensor.byte_offset)
-byte_offset(manager::DLManagedTensor) = byte_offset(manager.dl_tensor)
-byte_offset(array::DLArray) = byte_offset(array.manager)
+byte_offset(tensor::DLManagedTensor) = byte_offset(tensor.dl_tensor)
+byte_offset(manager::DLManager) = byte_offset(manager.tensor)
 
 Base.pointer(tensor::DLTensor) = tensor.data
-Base.pointer(manager::DLManagedTensor) = pointer(manager.dl_tensor)
-Base.pointer(array::DLArray) = pointer(array.manager)
+Base.pointer(tensor::DLManagedTensor) = pointer(tensor.dl_tensor)
+Base.pointer(manager::DLManager) = pointer(manager.tensor)
 
-function Base.unsafe_wrap(::Type{Array}, array::DLArray{T}) where {T}
-    if device_type(array) == kDLCPU
-        addr = Int(pointer(array))
-        return GC.@preserve array unsafe_wrap(Array, Ptr{T}(addr), size(array))
+function Base.unsafe_wrap(::Type{Array}, manager::DLManager{T}) where {T}
+    if device_type(manager) == kDLCPU
+        addr = Int(pointer(manager))
+        sz = unsafe_size(manager)
+        return GC.@preserve manager unsafe_wrap(Array, Ptr{T}(addr), sz)
     end
     throw(ArgumentError("Only CPU arrays can be wrapped with Array"))
+end
+#
+function Base.unsafe_wrap(::Type{CuArray}, manager::DLManager{T}) where {T}
+    if device_type(manager) == kDLCUDA
+        addr = Int(pointer(manager))
+        sz = unsafe_size(manager)
+        return GC.@preserve manager unsafe_wrap(CuArray, CuPtr{T}(addr), sz)
+    end
+    throw(ArgumentError("Only CUDA arrays can be wrapped with CuArray"))
+end
+
+function is_col_major(manager::DLManager{T, N})::Bool where {T, N}
+    return is_col_major(manager.tensor, Val(N))
+end
+#
+function is_col_major(tensor::DLManagedTensor, val::Val{N})::Bool where {N}
+    sz = unsafe_size(tensor, val)
+    st = unsafe_strides(tensor, val)
+    return N == 0 || prod(sz) == 0 || st == Base.size_to_strides(1, sz...)
+end
+
+reversedims_maybe(::Type{RowMajor}, array) = reversedims(array)
+reversedims_maybe(::Type{ColMajor}, array) = array
+
+function reversedims(a::AbstractArray)
+    return revdimstype(a)(reshape(a, (reverse ∘ size)(a)))
+end
+
+function revdimstype(a::A) where {T, N, A <: AbstractArray{T, N}}
+    P = ntuple(i -> N + 1 - i, Val(N))
+    return PermutedDimsArray{T, N, P, P, A}
 end
 
 
 ##  Module initialization  ##
 
 function __init__()
-
-    @require CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba" begin
-        include("cuda.jl")
-    end
 
     @require PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0" begin
         include("pycall.jl")

--- a/src/cuda.jl
+++ b/src/cuda.jl
@@ -1,9 +1,0 @@
-function Base.unsafe_wrap(::Type{CUDA.CuArray}, array::DLArray{T}) where {T}
-    if device_type(array) == kDLCUDA
-        addr = Int(pointer(array))
-        return GC.@preserve array unsafe_wrap(
-            CUDA.CuArray, CUDA.CuPtr{T}(addr), size(array)
-        )
-    end
-    throw(ArgumentError("Only CUDA arrays can be wrapped with CuArray"))
-end

--- a/src/pycall.jl
+++ b/src/pycall.jl
@@ -36,5 +36,8 @@ function DLManagedTensor(po::PyObject)
     return tensor
 end
 
-DLArray(po::PyObject) = DLArray(DLManagedTensor(po))
-DLArray{T, N}(po::PyObject) where {T, N} = DLArray{T, N}(DLManagedTensor(po))
+DLArray(o::PyObject, to_dlpack) = DLArray(DLManagedTensor(to_dlpack(o)), o)
+#
+function DLArray{T, N}(::Type{A}, ::Type{M}, o::PyObject, to_dlpack) where {T, N, A, M}
+    return DLArray{T, N}(A, M, DLManagedTensor(to_dlpack(o)), o)
+end

--- a/src/pythoncall.jl
+++ b/src/pythoncall.jl
@@ -54,5 +54,8 @@ let
 
 end
 
-DLArray(po::PythonCall.Py) = DLArray(DLManagedTensor(po))
-DLArray{T, N}(po::PythonCall.Py) where {T, N} = DLArray{T, N}(DLManagedTensor(po))
+DLArray(o::PythonCall.Py, to_dlpack) = DLArray(DLManagedTensor(to_dlpack(o)), o)
+#
+function DLArray{T, N}(::Type{A}, ::Type{M}, o::PythonCall.Py, to_dlpack) where {T, N, A, M}
+    return DLArray{T, N}(A, M, DLManagedTensor(to_dlpack(o)), o)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,7 +33,7 @@ jax.config.update("jax_enable_x64", true)
     if DLPack.device_type(opaque_tensor) == DLPack.kDLCPU
         dlv.data[1] = 0  # mutate a jax's tensor
         @inferred DLVector{Float32}(Array, ColMajor, v, to_dlpack)
-    elseif DLPack.device_type(opaque_tensor) == DLPack.kDLGPU
+    elseif DLPack.device_type(opaque_tensor) == DLPack.kDLCUDA
         dlv.data[1:1] .= 0  # mutate a jax's tensor
         @inferred DLVector{Float32}(CuArray, ColMajor, v, to_dlpack)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,42 +21,36 @@ jax.config.update("jax_enable_x64", true)
 
 
 @testset "PyCall" begin
+    to_dlpack = o -> @pycall dlpack.to_dlpack(o)::PyObject
 
     v = np.asarray([1.0, 2.0, 3.0], dtype = np.float32)
+    dlv = DLArray(v, to_dlpack)
+    opaque_tensor = dlv.manager.tensor.dl_tensor
 
-    v_capsule = @pycall dlpack.to_dlpack(v)::PyObject
-    dlv = DLVector{Float32}(v_capsule)
-    # We can only wrap once
-    @test_throws ArgumentError DLArray(v_capsule)
+    @test v.ndim == 1 == ndims(dlv)
+    @test opaque_tensor.dtype == DLPack.jltypes_to_dtypes()[eltype(dlv)]
 
-    tensor = dlv.manager.dl_tensor
-    @test tensor.ndim == 1 == ndims(dlv)
-    @test tensor.dtype == DLPack.jltypes_to_dtypes()[eltype(dlv)]
-
-    if DLPack.device_type(dlv) == DLPack.kDLCPU
-        jv = unsafe_wrap(Array, dlv)
-        jv[1] = 0  # mutate a jax's tensor
-    elseif DLPack.device_type(dlv) == DLPack.kDLGPU
-        jv = unsafe_wrap(CuArray, dlv)
-        jv[1:1] .= 0  # mutate a jax's tensor
+    if DLPack.device_type(opaque_tensor) == DLPack.kDLCPU
+        dlv.data[1] = 0  # mutate a jax's tensor
+        @inferred DLVector{Float32}(Array, ColMajor, v, to_dlpack)
+    elseif DLPack.device_type(opaque_tensor) == DLPack.kDLGPU
+        dlv.data[1:1] .= 0  # mutate a jax's tensor
+        @inferred DLVector{Float32}(CuArray, ColMajor, v, to_dlpack)
     end
 
     @test py"$np.all($v[:] == $np.asarray([0.0, 2.0, 3.0])).item()"
 
     w = np.asarray([1 2; 3 4], dtype = np.int64)
+    dlw = DLArray(w, to_dlpack)
+    opaque_tensor = dlw.manager.tensor.dl_tensor
 
-    dlw = DLArray(@pycall dlpack.to_dlpack(w)::PyObject)
-    tensw = dlw.manager.dl_tensor
+    @test w.ndim == 2 == ndims(dlw)
+    @test opaque_tensor.dtype == DLPack.jltypes_to_dtypes()[eltype(dlw)]
 
-    @test tensw.ndim == 2 == ndims(dlw)
-    @test tensw.dtype == DLPack.jltypes_to_dtypes()[eltype(dlw)]
-
-    if DLPack.device_type(dlw) == DLPack.kDLCPU
-        jw = unsafe_wrap(Array, dlw)
-        @test jw[2, 1] == 2
-    elseif DLPack.device_type(dlw) == DLPack.kDLCUDA
-        jw = unsafe_wrap(CuArray, dlw)
-        @test all(view(jw, 2, 1) .== 2)
+    if DLPack.device_type(opaque_tensor) == DLPack.kDLCPU
+        @test dlw.data[2, 1] == 3
+    elseif DLPack.device_type(opaque_tensor) == DLPack.kDLCUDA
+        @test all(view(dlw.data, 2, 1) .== 3)
     end
 
 end
@@ -65,25 +59,22 @@ end
 @testset "PythonCall" begin
 
     v = torch.ones((2, 4), dtype = torch.float64)
+    dlv = DLArray(v, torch.to_dlpack)
+    opaque_tensor = dlv.manager.tensor.dl_tensor
 
-    v_capsule = torch.to_dlpack(v)
-    dlv = DLMatrix{Float64}(v_capsule)
-    # We can only wrap once
-    @test_throws ArgumentError DLMatrix{Float64}(v_capsule)
+    @test pyconvert(Int,opaque_tensor.ndim) == 2 == ndims(dlv)
+    @test opaque_tensor.dtype == DLPack.jltypes_to_dtypes()[eltype(dlv)]
+    @test dlv.data isa PermutedDimsArray
 
-    tensor = dlv.manager.dl_tensor
-    @test tensor.ndim == 2 == ndims(dlv)
-    @test tensor.dtype == DLPack.jltypes_to_dtypes()[eltype(dlv)]
-
-    if DLPack.device_type(dlv) == DLPack.kDLCPU
-        jv = unsafe_wrap(Array, dlv)
-        jv[1] = 0  # mutate a jax's tensor
-    elseif DLPack.device_type(dlv) == DLPack.kDLGPU
-        jv = unsafe_wrap(CuArray, dlv)
-        jv[1:1] .= 0  # mutate a jax's tensor
+    if DLPack.device_type(opaque_tensor) == DLPack.kDLCPU
+        dlv.data[2] = 0  # mutate a jax's tensor
+        @inferred DLMatrix{Float64}(Array, RowMajor, v, torch.to_dlpack)
+    elseif DLPack.device_type(opaque_tensor) == DLPack.kDLGPU
+        dlv.data[2:2] .= 0  # mutate a jax's tensor
+        @inferred DLMatrix{Float64}(CuArray, RowMajor, v, torch.to_dlpack)
     end
 
-    ref = torch.tensor(((0, 1, 1, 1), (1, 1, 1, 1)), dtype = torch.float64)
+    ref = torch.tensor(((1, 1, 1, 1), (0, 1, 1, 1)), dtype = torch.float64)
     @test Bool(torch.all(v == ref).item())
 
 end


### PR DESCRIPTION
This redefines `DLArray` as a higher order type. ~~The previous definition would now be called `DLCapsule`, and~~ `DLArray` would now handle some of the wrapping mentioned in #10.

With this, importing would be done as

```julia
dla = DLArray(tensor, to_dlpack)
dla.data isa PermutedDimsArray  # true only if tensor is RowMajor
```

Anyway, I'm open to suggestions here @rejuvyesh.