### PR TITLE
Update DLPack.jl

### DIFF
--- a/src/DLPack.jl
+++ b/src/DLPack.jl
@@ -365,10 +365,12 @@ function is_col_major(manager::DLManager{T, N})::Bool where {T, N}
     return is_col_major(manager.manager, Val(N))
 end
 #
-function is_col_major(manager::DLManagedTensor, val::Val{N})::Bool where {N}
+is_col_major(manager::DLManagedTensor, val::Val{0}) = true
+                    
+function is_col_major(manager::DLManagedTensor, val::Val)::Bool
     sz = unsafe_size(manager, val)
     st = unsafe_strides(manager, val)
-    return N == 0 || prod(sz) == 0 || st == Base.size_to_strides(1, sz...)
+    return prod(sz) == 0 || st == Base.size_to_strides(1, sz...)
 end
 
 reshape_me_maybe(::Type{RowMajor}, array) = reshape(array, (reverse ∘ size)(array))


### PR DESCRIPTION
This should fix the following error.

```
ERROR: ArgumentError: Cannot call tail on an empty tuple.
Stacktrace:
  [1] tail(#unused#::Tuple{})
    @ Base ./essentials.jl:257
  [2] (::ComposedFunction{ComposedFunction{ComposedFunction{typeof(reverse), typeof(cumprod)}, typeof(reverse)}, typeof(Base.tail)})(x::Tuple{}; kw::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
    @ Base ./operators.jl:1085
  [3] (::ComposedFunction{ComposedFunction{ComposedFunction{typeof(reverse), typeof(cumprod)}, typeof(reverse)}, typeof(Base.tail)})(x::Tuple{})
    @ Base ./operators.jl:1085
  [4] unsafe_strides
    @ ~/.julia/packages/DLPack/XGB5a/src/DLPack.jl:340 [inlined]
  [5] is_col_major
    @ ~/.julia/packages/DLPack/XGB5a/src/DLPack.jl:370 [inlined]
  [6] is_col_major(manager::DLPack.DLManager{Float32, 0})
    @ DLPack ~/.julia/packages/DLPack/XGB5a/src/DLPack.jl:365
  [7] unsafe_wrap(manager::DLPack.DLManagedTensor, foreign::PyObject)
    @ DLPack ~/.julia/packages/DLPack/XGB5a/src/DLPack.jl:195
  [8] wrap(o::PyObject, to_dlpack::var"#7#8")
    @ DLPack ~/.julia/packages/DLPack/XGB5a/src/pycall.jl:66
  [9] top-level scope
    @ REPL[24]:1
 [10] top-level scope
    @ ~/.julia/packages/CUDA/tTK8Y/src/initialization.jl:52
```