### PR TITLE
Check the contiguous of DLTensor when wrapping it to Array

### DIFF
--- a/src/DLPack.jl
+++ b/src/DLPack.jl
@@ -366,11 +366,17 @@ function is_col_major(manager::DLManager{T, N})::Bool where {T, N}
 end
 #
 is_col_major(manager::DLManagedTensor, val::Val{0}) = true
-                    
+
 function is_col_major(manager::DLManagedTensor, val::Val)::Bool
     sz = unsafe_size(manager, val)
     st = unsafe_strides(manager, val)
-    return prod(sz) == 0 || st == Base.size_to_strides(1, sz...)
+    if prod(sz) == 0 || st == Base.size_to_strides(1, sz...)
+        return true
+    elseif reverse(st) == Base.size_to_strides(1, reverse(sz)...)
+        return false
+    else
+        throw(ArgumentError("Only contiguous arrays can be wrapped with Array"))
+    end
 end
 
 reshape_me_maybe(::Type{RowMajor}, array) = reshape(array, (reverse ∘ size)(array))

--- a/src/DLPack.jl
+++ b/src/DLPack.jl
@@ -370,10 +370,10 @@ is_col_major(manager::DLManagedTensor, val::Val{0}) = true
 function is_col_major(manager::DLManagedTensor, val::Val)::Bool
     sz = unsafe_size(manager, val)
     st = unsafe_strides(manager, val)
-    if prod(sz) == 0 || st == Base.size_to_strides(1, sz...)
-        return true
-    elseif reverse(st) == Base.size_to_strides(1, reverse(sz)...)
+    if reverse(st) == Base.size_to_strides(1, reverse(sz)...)
         return false
+    elseif prod(sz) == 0 || st == Base.size_to_strides(1, sz...)
+        return true
     else
         throw(ArgumentError("Only contiguous arrays can be wrapped with Array"))
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -100,6 +100,15 @@ end
 
         ref = torch.tensor(((1, 1, 1, 1), (0, 1, 1, 1)), dtype = torch.float64)
         @test Bool(torch.all(v == ref).item())
+
+        # tensor with Col-Major layout
+        w = v.T
+        jw = DLPack.wrap(w, torch.to_dlpack)
+        @test size(jw) == (4, 2)
+
+        # tensor with non-contiguous array
+        x = torch.ones((2, 3, 4), dtype = torch.int64).transpose(2, 1)
+        @test_throws ArgumentError DLPack.wrap(x, torch.to_dlpack)
     end
 
     @testset "share" begin


### PR DESCRIPTION
As described in #29 

An array is not `col_major` doesn't means it's `row_major`, it could be non-contiguous, so throw an error here if the contiguous check didn't pass. (maybe we could copy the data with the information of strides, and wrap a new Array, but not a efficient way)  