### PR TITLE
Adds support for PyArray and PyIterable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
         arch: [x64]
     steps:
       - uses: actions/checkout@v3
+      - name: Install system prerequisites
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y patchelf
       - name: Setup julia
         uses: julia-actions/setup-julia@v1
         with:

--- a/test/pythoncall.jl
+++ b/test/pythoncall.jl
@@ -4,8 +4,8 @@
     using PythonCall
 
 
-    const np = pyimport("numpy")
     const torch = pyimport("torch")
+    const np = pyimport("numpy")
 
 
     @testset "wrap" begin


### PR DESCRIPTION
When called from juliacall, the automatic conversion rules might turn `numpy.ndarray`s into `PyArray`s and `torch.Tensor`s into `PyIterable`s. This PR adds support for both `PyArray` and `PyIterable` such that `DLPack.from_dpack` works out of the box from juliacall.