### PR TITLE
Correctly handle python arrays with leading singleton dimensions

### DIFF
--- a/src/DLPack.jl
+++ b/src/DLPack.jl
@@ -414,7 +414,8 @@ is_col_major(manager::DLManagedTensor, val::Val{0}) = true
 function is_col_major(manager::DLManagedTensor, val::Val)::Bool
     sz = unsafe_size(manager, val)
     st = unsafe_strides(manager, val)
-    return prod(sz) == 0 || st == Base.size_to_strides(1, sz...)
+    number_of_elements = prod(sz)
+    return number_of_elements == 0 || (st == Base.size_to_strides(1, sz...) && number_of_elements > sz[end])
 end
 
 reshape_me_maybe(::Type{RowMajor}, array) = reshape(array, (reverse ∘ size)(array))


### PR DESCRIPTION
The current `main` branch does not handle python arrays/tensors with leading sinleton dimensions (i.e. of shape `1x...x1xN`) correctly because it will incorrectly assume that they are already column major. That is, prior to this PR, one can observe the following bug:

```julia
using DLPack: DLPack
using PythonCall: PythonCall
using Test: @test

py_torch = PythonCall.pyimport("torch")

# creating a vector on the Python side
py_torch_tensor = py_torch.randn((1, 1, 2))
@show py_torch_tensor
@show py_torch_tensor.shape

julia_tensor = DLPack.from_dlpack(py_torch_tensor)
@show julia_tensor # observe how the shape has been reversed to account for row- vs. column-major order
@show size(julia_tensor)

@test size(julia_tensor) == (2, 1, 1) # fails because the current code classifies the (1,1, 2) python array as column major, thus causing `from_dlpack` to return a (1, 1, 2) julia array.
```

This PR fixes that behavior by explicitly checking for row vectors.

That said, I am not sure if special-casing it like that is correct in general so a careful review is very welcome.