### PR TITLE
rename extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /Manifest.toml
+.CondaPkg/

--- a/Project.toml
+++ b/Project.toml
@@ -10,12 +10,11 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 [weakdeps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
-PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 
 [extensions]
-CUDAExt = "CUDA"
-PyCallExt = "PyCall"
-PythonCallExt = "PythonCall"
+DLPackCUDAExt = "CUDA"
+DLPackPyCallExt = "PyCall"
+DLPackPythonCallExt = "PythonCall"
 
 [compat]
 Aqua = "0.8"
@@ -29,8 +28,8 @@ julia = "1.3"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/ext/DLPackCUDAExt.jl
+++ b/ext/DLPackCUDAExt.jl
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 # See LICENSE.md at https://github.com/pabloferz/DLPack.jl
 
-module CUDAExt
+module DLPackCUDAExt
 
 
 ##  Dependencies  ##
@@ -50,4 +50,4 @@ function Base.unsafe_wrap(::Type{<: CUDA.CuArray}, manager::DLPack.DLManager{T})
 end
 
 
-end  # module CUDAExt
+end  # module DLPackCUDAExt

--- a/ext/DLPackPyCallExt.jl
+++ b/ext/DLPackPyCallExt.jl
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 # See LICENSE.md at https://github.com/pabloferz/DLPack.jl
 
-module PyCallExt
+module DLPackPyCallExt
 
 
 ##  Dependencies  ##
@@ -180,4 +180,4 @@ function __init__()
 end
 
 
-end  # module PyCallExt
+end  # module DLPackPyCallExt

--- a/ext/DLPackPythonCallExt.jl
+++ b/ext/DLPackPythonCallExt.jl
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 # See LICENSE.md at https://github.com/pabloferz/DLPack.jl
 
-module PythonCallExt
+module DLPackPythonCallExt
 
 
 ##  Dependencies  ##
@@ -189,4 +189,4 @@ function __init__()
 end
 
 
-end  # module PythonCallExt
+end  # module DLPackPythonCallExt

--- a/src/DLPack.jl
+++ b/src/DLPack.jl
@@ -436,13 +436,13 @@ function __init__()
 
     if !isdefined(Base, :get_extension)
         @require CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba" begin
-            include("../ext/CUDAExt.jl")
+            include("../ext/DLPackCUDAExt.jl")
         end
         @require PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0" begin
-            include("../ext/PyCallExt.jl")
+            include("../ext/DLPackPyCallExt.jl")
         end
         @require PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d" begin
-            include("../ext/PythonCallExt.jl")
+            include("../ext/DLPackPythonCallExt.jl")
         end
     end
 end


### PR DESCRIPTION
Use standard convention for the naming, so that naming conflicts with other packages' extensions are avoided